### PR TITLE
Add quotation boolean field to website schema

### DIFF
--- a/schemas/documentSchemas/website.ts
+++ b/schemas/documentSchemas/website.ts
@@ -23,6 +23,13 @@ export default defineType({
       type: "string",
     }),
     simpleDescriptionField,
+    defineField({
+      name: "directlyQuoted",
+      title: "Description text quoted directly",
+      description: `Some or all of the description text was taken directly from the source wesbite`,
+      type: "boolean",
+      initialValue: false,
+    }),
     urlField,
     defineField({
       title: "Logo",


### PR DESCRIPTION
Implements a boolean field on 'wesbite' document schema to enable indication of whether a description was quoted directly from its source website