### PR TITLE
#45 - regex url validation for paths feature added

### DIFF
--- a/schemas/fields/urlField.ts
+++ b/schemas/fields/urlField.ts
@@ -4,9 +4,18 @@ import ResourceUrlInput from "../../components/ResourceUrlInput";
 const urlField = defineField({
   title: "URL",
   description:
-    "This should be a valid web address, usually starting with 'https://'",
+    "This should be a valid web address, usually starting with 'https://'. Paths may be used but be aware this likely points to a specific resource, rather than a website overall.",
   name: "resourceUrl",
   type: "url",
+  validation: (Rule) =>
+    Rule.custom((resourceUrl) => {
+      const pattern = new RegExp("http[s]*://[^/]+(/.+)");
+      if (pattern.test(resourceUrl)) {
+        return "Warning: URL Contains A Path";
+      } else {
+        return true;
+      }
+    }),
   components: {
     input: ResourceUrlInput,
   },


### PR DESCRIPTION
Custom validation added for URL that contains a path after the domain. Seems to be working ok. 