### PR TITLE
Migrate content block obj to doc

### DIFF
--- a/migrations/migrate-contentblock-object-to-references-in-contentgroup/index.ts
+++ b/migrations/migrate-contentblock-object-to-references-in-contentgroup/index.ts
@@ -1,0 +1,49 @@
+import { v4 as uuid } from "uuid";
+import {
+  at,
+  createIfNotExists,
+  defineMigration,
+  patch,
+  replace,
+} from "sanity/migrate";
+
+export default defineMigration({
+  title: "Migrate contentBlock object to references in contentGroup",
+  documentTypes: ["contentGroup"],
+  filter: "defined(contentBlocks) && count(contentBlocks[]._ref) > 0",
+  migrate: {
+    document(contentGroup) {
+      const currentContentBlocks = contentGroup.contentBlocks;
+
+      // Migrate any contentBlocks object to a new document
+      if (
+        Array.isArray(currentContentBlocks) &&
+        currentContentBlocks.length > 0
+      ) {
+        return currentContentBlocks
+          .filter((block) => !block._ref)
+          .flatMap((block, i) => {
+            const blockId = uuid();
+
+            const { _key, ...blockAttributes } = block || {};
+
+            return [
+              createIfNotExists({
+                _id: blockId,
+                _type: "contentBlock",
+                name: `Block ${i + 1} from: ${contentGroup.name}`,
+                ...blockAttributes,
+              }),
+              patch(
+                contentGroup._id,
+                at(
+                  ["contentBlocks"],
+                  replace([{ _type: "reference", _ref: blockId }], { _key })
+                )
+              ),
+            ];
+          });
+      }
+    },
+  },
+});

--- a/schemas/documentSchemas/contentBlock.ts
+++ b/schemas/documentSchemas/contentBlock.ts
@@ -9,14 +9,23 @@ export default defineType({
     "A Content Block allows you to build a section of content from predefined building blocks",
   preview: {
     select: {
+      name: "name",
+      title: "title",
       content: "content",
     },
-    prepare: ({ content }) => ({
-      title: `Content Block`,
+    prepare: ({ name, content }) => ({
+      title: name,
       subtitle: content?.map((x: any) => startCase(x._type)).join(", "),
     }),
   },
   fields: [
+    defineField({
+      name: "name",
+      description:
+        "Meaningful name for distinguishing this content block within Sanity (not displayed to users)",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
     defineField({
       title: "Title",
       name: "title",

--- a/schemas/documentSchemas/contentBlock.ts
+++ b/schemas/documentSchemas/contentBlock.ts
@@ -3,7 +3,7 @@ import { portableTextDescriptionField } from "../fields";
 import startCase from "lodash/startCase";
 
 export default defineType({
-  type: "object",
+  type: "document",
   name: "contentBlock",
   description:
     "A Content Block allows you to build a section of content from predefined building blocks",

--- a/schemas/documentSchemas/contentGroup.ts
+++ b/schemas/documentSchemas/contentGroup.ts
@@ -46,7 +46,9 @@ export default defineType({
       title: "Content Blocks",
       description: `Build a Content Group from Content Blocks. You can think of a Content Block as a "section" within the group`,
       type: "array",
-      of: [defineArrayMember({ type: "contentBlock" })],
+      of: [
+        defineArrayMember({ type: "reference", to: { type: "contentBlock" } }),
+      ],
     }),
     defineField({
       name: "contentGroupJumpLink",

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,5 +1,6 @@
 import aboutPage from "./documentSchemas/aboutPage";
 import category from "./documentSchemas/category";
+import contentBlock from "./documentSchemas/contentBlock";
 import contentGroup from "./documentSchemas/contentGroup";
 import coreContentGroups from "./documentSchemas/coreContentGroups";
 import crisisResource from "./documentSchemas/crisisResource";
@@ -37,7 +38,6 @@ import webinar from "./internetResourceDocumentSchemas/webinar";
 import accessibleImage from "./objectSchemas/accessibleImage";
 import availability from "./objectSchemas/availability";
 import contactMethod from "./objectSchemas/contactMethod";
-import contentBlock from "./objectSchemas/contentBlock";
 import coreContentGroup from "./objectSchemas/coreContentGroup";
 import coreValue from "./objectSchemas/coreValue";
 import customResourceCollection from "./objectSchemas/customResourceCollection";
@@ -64,7 +64,6 @@ export const objectTypes = [
   contactMethod,
   coreValue,
   coreContentGroup,
-  contentBlock,
   customResourceCollection,
   featuredCrisisResource,
   featuredResource,
@@ -106,6 +105,7 @@ export const internetResourceDocumentTypes = [
 
 export const documentTypes = [
   category,
+  contentBlock,
   contentGroup,
   topicCollection,
   smartCategory,


### PR DESCRIPTION
Migrate 'contentBlock' inline objects to referenced documents for reusability