### PR TITLE
Fix dataset preparation workflow

### DIFF
--- a/.github/workflows/prepare-datasets.yml
+++ b/.github/workflows/prepare-datasets.yml
@@ -10,7 +10,7 @@ jobs:
   prepare-datasets:
     runs-on: ubuntu-latest
     env:
-      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN_TEST }}
       SANITY_STUDIO_PROJECT_ID: ${{ vars.SANITY_STUDIO_PROJECT_ID }}
 
     steps:

--- a/.github/workflows/prepare-datasets.yml
+++ b/.github/workflows/prepare-datasets.yml
@@ -31,13 +31,13 @@ jobs:
           npx -y sanity@latest dataset export production production.tar.gz --overwrite
 
       # Does not work on 'free' plan - editor grant cannot delete a dataset via API token
-      # - name: Delete existing 'dev' dataset
-      #   run: |
-      #     npx -y sanity@latest dataset delete dev --force
+      - name: Delete existing 'dev' dataset
+        run: |
+          npx -y sanity@latest dataset delete dev --force
 
-      # - name: Create new 'dev' dataset
-      #   run: |
-      #     npx -y sanity@latest dataset create dev
+      - name: Create new 'dev' dataset
+        run: |
+          npx -y sanity@latest dataset create dev
 
       # We have to accept that for now we can't have a completely "clean" dataset
       - name: Import data into new 'dev' dataset

--- a/.github/workflows/prepare-datasets.yml
+++ b/.github/workflows/prepare-datasets.yml
@@ -10,7 +10,7 @@ jobs:
   prepare-datasets:
     runs-on: ubuntu-latest
     env:
-      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN_TEST }}
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
       SANITY_STUDIO_PROJECT_ID: ${{ vars.SANITY_STUDIO_PROJECT_ID }}
 
     steps:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "lts/*"
 
       - name: Install dependencies
         run: |
@@ -30,16 +30,14 @@ jobs:
         run: |
           npx -y sanity@latest dataset export production production.tar.gz --overwrite
 
-      # Does not work on 'free' plan - editor grant cannot delete a dataset via API token
       - name: Delete existing 'dev' dataset
         run: |
           npx -y sanity@latest dataset delete dev --force
 
       - name: Create new 'dev' dataset
         run: |
-          npx -y sanity@latest dataset create dev
+          npx -y sanity@latest dataset create dev --visibility public
 
-      # We have to accept that for now we can't have a completely "clean" dataset
       - name: Import data into new 'dev' dataset
         run: |
           npx -y sanity@latest dataset import production.tar.gz dev --replace


### PR DESCRIPTION
Adds back the desired 'delete' 'create' step for the 'dev' dataset so that we have a clean 'dev' dataset with each branch creation