### PR TITLE
Dc new navigation schema

### DIFF
--- a/schemas/documentSchemas/causeOfDeath.ts
+++ b/schemas/documentSchemas/causeOfDeath.ts
@@ -21,11 +21,10 @@ export default defineType({
     select: {
       displayTitle: "displayTitle",
       title: "title",
-      slug: "slug.current",
     },
-    prepare: ({ displayTitle, title, slug }) => ({
+    prepare: ({ displayTitle, title }) => ({
       title: displayTitle ?? title,
-      subtitle: slug,
+      subtitle: `Cause of Death`,
     }),
   },
   fields: [

--- a/schemas/documentSchemas/contentFunction.ts
+++ b/schemas/documentSchemas/contentFunction.ts
@@ -1,5 +1,6 @@
 import { defineField, defineType } from "sanity";
 import { BulbOutlineIcon } from "@sanity/icons";
+
 import slugField from "../fields/slugField";
 import tagSearchAliasesField from "../fields/tagSearchAliasesField";
 
@@ -8,6 +9,15 @@ export default defineType({
   title: "Content Function",
   icon: BulbOutlineIcon,
   type: "document",
+  preview: {
+    select: {
+      title: "title",
+    },
+    prepare: ({ title }) => ({
+      title: title,
+      subtitle: `Content Function`,
+    }),
+  },
   fields: [
     defineField({
       title: "Title",
@@ -29,7 +39,4 @@ export default defineType({
     }),
     tagSearchAliasesField,
   ],
-  preview: {
-    select: { title: "title", subtitle: "description" },
-  },
 });

--- a/schemas/documentSchemas/demographic.ts
+++ b/schemas/documentSchemas/demographic.ts
@@ -1,5 +1,6 @@
 import { defineField, defineType } from "sanity";
 import { TagsIcon } from "@sanity/icons";
+
 import imageAssetField from "../fields/imageAssetField";
 import slugField from "../fields/slugField";
 import tagSearchAliasesField from "../fields/tagSearchAliasesField";
@@ -12,6 +13,15 @@ export default defineType({
     "A demographic describes a specific identity or community of people",
   icon: TagsIcon,
   type: "document",
+  preview: {
+    select: {
+      title: "name",
+    },
+    prepare: ({ title }) => ({
+      title,
+      subtitle: `Demographic`,
+    }),
+  },
   fields: [
     defineField({
       title: "Demographic Name",

--- a/schemas/documentSchemas/emotionalState.ts
+++ b/schemas/documentSchemas/emotionalState.ts
@@ -8,6 +8,15 @@ export default defineType({
   title: "Emotional State",
   icon: SparkleIcon,
   type: "document",
+  preview: {
+    select: {
+      title: "title",
+    },
+    prepare: ({ title }) => ({
+      title: title,
+      subtitle: `Emotion`,
+    }),
+  },
   fields: [
     defineField({
       title: "Title",
@@ -27,7 +36,4 @@ export default defineType({
     }),
     tagSearchAliasesField,
   ],
-  preview: {
-    select: { title: "title", subtitle: "description" },
-  },
 });

--- a/schemas/documentSchemas/griefPhase.ts
+++ b/schemas/documentSchemas/griefPhase.ts
@@ -1,5 +1,6 @@
 import { defineField, defineType } from "sanity";
 import { ClockIcon } from "@sanity/icons";
+
 import slugField from "../fields/slugField";
 import tagSearchAliasesField from "../fields/tagSearchAliasesField";
 
@@ -8,6 +9,15 @@ export default defineType({
   title: "Grief Phase",
   icon: ClockIcon,
   type: "document",
+  preview: {
+    select: {
+      title: "title",
+    },
+    prepare: ({ title }) => ({
+      title: title,
+      subtitle: `Grief Phase`,
+    }),
+  },
   fields: [
     defineField({
       title: "Title",
@@ -29,7 +39,4 @@ export default defineType({
     }),
     tagSearchAliasesField,
   ],
-  preview: {
-    select: { title: "title", subtitle: "description" },
-  },
 });

--- a/schemas/documentSchemas/griefType.ts
+++ b/schemas/documentSchemas/griefType.ts
@@ -1,5 +1,6 @@
 import { defineField, defineType } from "sanity";
 import { ClockIcon } from "@sanity/icons";
+
 import slugField from "../fields/slugField";
 import tagSearchAliasesField from "../fields/tagSearchAliasesField";
 
@@ -8,6 +9,15 @@ export default defineType({
   title: "Grief Type",
   icon: ClockIcon,
   type: "document",
+  preview: {
+    select: {
+      title: "title",
+    },
+    prepare: ({ title }) => ({
+      title: title,
+      subtitle: `Grief Type`,
+    }),
+  },
   fields: [
     defineField({
       title: "Title",
@@ -29,7 +39,4 @@ export default defineType({
     }),
     tagSearchAliasesField,
   ],
-  preview: {
-    select: { title: "title", subtitle: "description" },
-  },
 });

--- a/schemas/documentSchemas/lossRelationship.ts
+++ b/schemas/documentSchemas/lossRelationship.ts
@@ -19,13 +19,11 @@ export default defineType({
   type: "document",
   preview: {
     select: {
-      displayTitle: "displayTitle",
       title: "title",
-      slug: "slug.current",
     },
-    prepare: ({ displayTitle, title, slug }) => ({
-      title: displayTitle ?? title,
-      subtitle: slug,
+    prepare: ({ title }) => ({
+      title: title,
+      subtitle: `Primary Loss Type`,
     }),
   },
   fields: [

--- a/schemas/documentSchemas/navigationTree.ts
+++ b/schemas/documentSchemas/navigationTree.ts
@@ -1,0 +1,35 @@
+import { MenuIcon } from "@sanity/icons";
+import { defineArrayMember, defineField, defineType } from "sanity";
+import slugField from "../fields/slugField";
+import titleField from "../fields/titleField";
+
+export default defineType({
+  name: "navigationTree",
+  title: "Navigation Tree",
+  type: "document",
+  icon: MenuIcon,
+  description:
+    "Defines a hierarchical navigation. It is made up of nav items and groups of nav items that create a hierarchical tree structure",
+  fields: [
+    slugField,
+    defineField({
+      ...titleField,
+      description:
+        "Title for distinguishing this navigation tree in Sanity. Never used for presentation",
+    }),
+    defineField({
+      name: "navigationTreeItems",
+      type: "array",
+      description:
+        "The items to include in this navigation tree. Can be Nav Item groups or single Nav Items",
+      of: [
+        defineArrayMember({
+          type: "navItem",
+        }),
+        defineArrayMember({
+          type: "navItemGroup",
+        }),
+      ],
+    }),
+  ],
+});

--- a/schemas/documentSchemas/theme.ts
+++ b/schemas/documentSchemas/theme.ts
@@ -19,13 +19,11 @@ export default defineType({
   type: "document",
   preview: {
     select: {
-      displayTitle: "displayTitle",
       title: "title",
-      slug: "slug.current",
     },
-    prepare: ({ displayTitle, title, slug }) => ({
-      title: displayTitle ?? title,
-      subtitle: slug,
+    prepare: ({ title }) => ({
+      title: title,
+      subtitle: `Theme`,
     }),
   },
   fields: [

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -13,6 +13,7 @@ import imageAsset from "./documentSchemas/imageAsset";
 import imageCollection from "./documentSchemas/imageCollection";
 import imageSource from "./documentSchemas/imageSource";
 import lossRelationship from "./documentSchemas/lossRelationship";
+import navigationTree from "./documentSchemas/navigationTree";
 import organization from "./documentSchemas/organization";
 import person from "./documentSchemas/person";
 import personGroup from "./documentSchemas/personGroup";
@@ -54,6 +55,8 @@ import headingText from "./objectSchemas/headingText";
 import imageRow from "./objectSchemas/imageRow";
 import link from "./objectSchemas/link";
 import logo from "./objectSchemas/logo";
+import navItem from "./objectSchemas/navItem";
+import navItemGroup from "./objectSchemas/navItemGroup";
 import pageLinks from "./objectSchemas/pageLinks";
 import personGroupBlock from "./objectSchemas/personGroupBlock";
 import relativeLink from "./objectSchemas/relativeLink";
@@ -63,8 +66,9 @@ import richTextContentBlock from "./objectSchemas/richTextContentBlock";
 import richTextWithHeading from "./objectSchemas/richTextWithHeading";
 import socials from "./objectSchemas/socials";
 import telephoneNumber from "./objectSchemas/telephoneNumber";
-import type { InternetResourceType } from "../shared/internet-resource";
+
 import type { SchemaTypeDefinition } from "sanity";
+import type { InternetResourceType } from "../shared/internet-resource";
 
 export const objectTypes = [
   availability,
@@ -79,6 +83,8 @@ export const objectTypes = [
   imageRow,
   link,
   logo,
+  navItem,
+  navItemGroup,
   pageLinks,
   personGroupBlock,
   relativeLink,
@@ -128,6 +134,7 @@ export const documentTypes = [
   imageAsset,
   imageCollection,
   imageSource,
+  navigationTree,
   person,
   personGroup,
   resourceEvaluation,

--- a/schemas/objectSchemas/navItem.ts
+++ b/schemas/objectSchemas/navItem.ts
@@ -1,0 +1,134 @@
+import { defineArrayMember, defineField, defineType } from "sanity";
+import { internetResourceTypes } from "../../shared/internet-resource";
+import startCase from "lodash/startCase";
+
+export default defineType({
+  name: "navItem",
+  type: "object",
+  title: "Navigation Item",
+  preview: {
+    select: {
+      label: "label",
+      entryPoint: "entryPoint.title",
+      filters: "filters",
+      types: "mediaTypes",
+    },
+    prepare: ({ label, entryPoint, filters, types }) => ({
+      title: label,
+      subtitle: `Goes to: '${entryPoint}'${(filters ?? types ?? []).length > 0 ? " with additional filters applied" : ""}`,
+    }),
+  },
+  fields: [
+    defineField({
+      name: "label",
+      title: "Label",
+      type: "string",
+    }),
+    defineField({
+      name: "entryPoint",
+      title: "Entry Point",
+      description:
+        "Each navigation item must target a core taxonomy reference as its entry point",
+      type: "reference",
+      to: [
+        { type: "lossRelationship" },
+        { type: "causeOfDeath" },
+        { type: "theme" },
+        { type: "demographic" },
+        { type: "griefPhase" },
+        { type: "griefType" },
+        { type: "emotionalState" },
+        { type: "contentFunction" },
+      ],
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "filters",
+      title: "Additional Filters",
+      description:
+        "Select any additional taxonomies this navigation item should target",
+      type: "array",
+      of: [
+        defineArrayMember({
+          type: "reference",
+          to: [
+            { type: "lossRelationship" },
+            { type: "causeOfDeath" },
+            { type: "theme" },
+            { type: "demographic" },
+            { type: "griefPhase" },
+            { type: "griefType" },
+            { type: "emotionalState" },
+            { type: "contentFunction" },
+          ],
+        }),
+      ],
+      validation: (rule) => [
+        rule.unique(),
+        rule.custom<Array<{ _ref?: string; _key?: string }>>(
+          async (filters, context) => {
+            const parent = context.parent as
+              | { entryPoint?: { _ref?: string } }
+              | undefined;
+
+            const entryRef = parent?.entryPoint?._ref;
+            if (!entryRef || !filters?.length) {
+              return true;
+            }
+
+            const refIds = filters
+              .map((f) => f._ref)
+              .filter((id): id is string => Boolean(id));
+            if (!refIds.length) {
+              return true;
+            }
+
+            const client = context.getClient({ apiVersion: "2024-01-01" });
+            const [entryType, filterDocs] = await Promise.all([
+              client.fetch<string | null>(`*[_id == $id][0]._type`, {
+                id: entryRef,
+              }),
+              client.fetch<Array<{ _id: string; _type: string }>>(
+                `*[_id in $ids]{ _id, _type }`,
+                { ids: refIds },
+              ),
+            ]);
+
+            if (!entryType) {
+              return true;
+            }
+
+            const conflictIds = new Set(
+              filterDocs.filter((d) => d._type === entryType).map((d) => d._id),
+            );
+            if (!conflictIds.size) {
+              return true;
+            }
+
+            return {
+              message: `Filters cannot include the same type as the entry point ("${entryType}")`,
+              paths: filters
+                .filter((f) => f._ref && conflictIds.has(f._ref) && f._key)
+                .map((f) => [{ _key: f._key! }]),
+            };
+          },
+        ),
+      ],
+    }),
+    defineField({
+      name: "mediaTypes",
+      title: "Resource Types",
+      description: "Specific media types to target. Leave empty for all types",
+      type: "array",
+      of: [{ type: "string" }],
+      options: {
+        list: [
+          ...internetResourceTypes.map((resourceType) => ({
+            value: resourceType,
+            title: startCase(resourceType),
+          })),
+        ],
+      },
+    }),
+  ],
+});

--- a/schemas/objectSchemas/navItemGroup.ts
+++ b/schemas/objectSchemas/navItemGroup.ts
@@ -1,0 +1,39 @@
+import { defineArrayMember, defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "navItemGroup",
+  type: "object",
+  title: "Navigation Item Group",
+  description: "Test",
+  preview: {
+    select: {
+      title: "label",
+    },
+    prepare: ({ title }) => ({
+      title,
+      subtitle: "Nav Item Group",
+    }),
+  },
+  fields: [
+    defineField({
+      name: "label",
+      title: "Label",
+      description: "A label for this group of navigation items",
+      type: "string",
+    }),
+    defineField({
+      name: "items",
+      title: "Items",
+      description: "The navigation items to include in this group",
+      type: "array",
+      of: [
+        defineArrayMember({
+          type: "navItem",
+        }),
+        defineArrayMember({
+          type: "navItemGroup",
+        }),
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
## What & Why

Adds new navigation tree schema for modelling navigation explicitly - rather than trying to infer it on the frontend

## How to Test

Create new navigation trees in the studio

## Checklist

- [x] Tested locally (`npm run dev`)
- [ ] `npm run lint` passes
- [ ] `npm run format:check` passes
- [ ] `npm run typecheck` passes
- [ ] Updated documentation if needed
